### PR TITLE
feat: Create custom links for osc type properties

### DIFF
--- a/fields.config.js
+++ b/fields.config.js
@@ -21,3 +21,30 @@ Registry.addMetadataField('contacts', {
     label: "Contacts",
     ext: "osc",
 });
+
+Registry.addMetadataField('osc:project', {
+  label: "Project",
+  ext: "osc",
+  formatter: value => Helper.toLink(`/stac-browser/#/projects/${value}/collection.json`, value)
+});
+
+Registry.addMetadataField('osc:themes', {
+  label: "Themes",
+  ext: "osc",
+  formatter: value =>
+    value.map(theme => Helper.toLink(`/stac-browser/#/themes/${theme}/catalog.json`, theme)).join(", ")
+});
+
+Registry.addMetadataField('osc:variables', {
+  label: "Variables",
+  ext: "osc",
+  formatter: value =>
+    value.map(variable => Helper.toLink(`/stac-browser/#/variables/${variable}/catalog.json`, variable)).join(", ")
+});
+
+Registry.addMetadataField('osc:missions', {
+  label: "Missions",
+  ext: "osc",
+  formatter: value =>
+    value.map(mission => Helper.toLink(`/stac-browser/#/eo-missions/${mission}/catalog.json`, mission)).join(", ")
+});

--- a/fields.config.js
+++ b/fields.config.js
@@ -25,26 +25,26 @@ Registry.addMetadataField('contacts', {
 Registry.addMetadataField('osc:project', {
   label: "Project",
   ext: "osc",
-  formatter: value => Helper.toLink(`/stac-browser/#/projects/${value}/collection.json`, value)
+  formatter: value => Helper.toLink(`/stac-browser/#/projects/${value}/collection.json`, value, "", "_self")
 });
 
 Registry.addMetadataField('osc:themes', {
   label: "Themes",
   ext: "osc",
   formatter: value =>
-    value.map(theme => Helper.toLink(`/stac-browser/#/themes/${theme}/catalog.json`, theme)).join(", ")
+    value.map(theme => Helper.toLink(`/stac-browser/#/themes/${theme}/catalog.json`, theme, "", "_self")).join(", ")
 });
 
 Registry.addMetadataField('osc:variables', {
   label: "Variables",
   ext: "osc",
   formatter: value =>
-    value.map(variable => Helper.toLink(`/stac-browser/#/variables/${variable}/catalog.json`, variable)).join(", ")
+    value.map(variable => Helper.toLink(`/stac-browser/#/variables/${variable}/catalog.json`, variable, "", "_self")).join(", ")
 });
 
 Registry.addMetadataField('osc:missions', {
   label: "Missions",
   ext: "osc",
   formatter: value =>
-    value.map(mission => Helper.toLink(`/stac-browser/#/eo-missions/${mission}/catalog.json`, mission)).join(", ")
+    value.map(mission => Helper.toLink(`/stac-browser/#/eo-missions/${mission}/catalog.json`, mission, "", "_self")).join(", ")
 });

--- a/fields.config.js
+++ b/fields.config.js
@@ -24,7 +24,7 @@ Registry.addMetadataField('contacts', {
 
 const formatLink = (type, value, links, jsonName) => {
   const link = links.find(link => link.rel === 'related' && link.href.includes(value));
-  return Helper.toLink(`/#/${type}/${value}/${jsonName}.json`, link.title.split(":")[1], "", "_self");
+  return Helper.toLink(`/stac-browser/#/${type}/${value}/${jsonName}.json`, link.title.split(":")[1], "", "_self");
 }
 
 Registry.addMetadataField('osc:project', {

--- a/fields.config.js
+++ b/fields.config.js
@@ -22,29 +22,36 @@ Registry.addMetadataField('contacts', {
     ext: "osc",
 });
 
+const formatLink = (type, value, links, jsonName) => {
+  const link = links.find(link => link.rel === 'related' && link.href.includes(value));
+  return Helper.toLink(`/#/${type}/${value}/${jsonName}.json`, link.title.split(":")[1], "", "_self");
+}
+
 Registry.addMetadataField('osc:project', {
   label: "Project",
   ext: "osc",
-  formatter: value => Helper.toLink(`/stac-browser/#/projects/${value}/collection.json`, value, "", "_self")
+  formatter: (value, field, spec, { links }) => {
+    return formatLink("projects", value, links, "collection")
+  }
 });
 
 Registry.addMetadataField('osc:themes', {
   label: "Themes",
   ext: "osc",
-  formatter: value =>
-    value.map(theme => Helper.toLink(`/stac-browser/#/themes/${theme}/catalog.json`, theme, "", "_self")).join(", ")
+  formatter: (value, field, spec, { links }) =>
+    value.map(theme => formatLink("themes", theme, links, "catalog")).join(", ")
 });
 
 Registry.addMetadataField('osc:variables', {
   label: "Variables",
   ext: "osc",
-  formatter: value =>
-    value.map(variable => Helper.toLink(`/stac-browser/#/variables/${variable}/catalog.json`, variable, "", "_self")).join(", ")
+  formatter: (value, field, spec, { links }) =>
+    value.map(variable => formatLink("variables", variable, links, "catalog")).join(", ")
 });
 
 Registry.addMetadataField('osc:missions', {
   label: "Missions",
   ext: "osc",
-  formatter: value =>
-    value.map(mission => Helper.toLink(`/stac-browser/#/eo-missions/${mission}/catalog.json`, mission, "", "_self")).join(", ")
+  formatter: (value, field, spec, { links }) =>
+    value.map(mission => formatLink("eo-missions", mission, links, "catalog")).join(", ")
 });


### PR DESCRIPTION
Todo:
- ~~[ ] fetch URLs directly from collection.json (https://github.com/ESA-EarthCODE/open-science-catalog-metadata/blob/f9841d5a4f791d0f7d3768eba42d88533ab66b94/products/absolute-sea-level-heights-baltics-sar-hsu/collection.json#L24-L59) instead of patching it together~~ (the links from the `collection.json` are in relative path which don't really work in our navigation)
- [x] make sure links work in iframed stac-browser

Demo:
![Animation2](https://github.com/user-attachments/assets/9d8f9a0d-7eff-481b-9c6b-fed7f5ef1746)


Closes #5 