### PR TITLE
fix: add watcher on data to update formatedData for metadata

### DIFF
--- a/src/components/Metadata.vue
+++ b/src/components/Metadata.vue
@@ -90,6 +90,12 @@ export default {
         this.formattedData = this.formatData();
       },
     },
+    data: {
+      immediate: true,
+      handler() {
+        this.formattedData = this.formatData();
+      }
+    }
   },
   methods: {
     formatData() {


### PR DESCRIPTION
In this PR I added a watcher to the `data` prop in `Metadata.vue` so that when it updates `formattedData` also gets updated
![git-clerk-3](https://github.com/user-attachments/assets/769b1fb0-5827-461d-8835-9efd44149a31)
