### PR TITLE
feat: fair assessment chart integration

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
     <meta name="og:locale" id="og-locale" content="en">
     <meta name="og:site_name" content="<%= htmlWebpackPlugin.options.title %>">
     <script defer="defer" src="./config.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@eox/chart/dist/eox-chart.js"></script>
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>

--- a/src/components/FairAssessment.vue
+++ b/src/components/FairAssessment.vue
@@ -54,7 +54,7 @@ export default {
         for (const metricName in groupData) {
           const metricData = groupData[metricName];
           const value = metricData.value;
-          const score = value ? 1 : 0;
+          const score = (typeof value === "number" ? value >= 0.5 : value) ? 1 : 0;
           const metricLabel = prettify(metricName);
 
           chartData.push({
@@ -89,7 +89,7 @@ export default {
         if (typeof value === "boolean") {
           score = value ? 1 : 0;
         } else if (typeof value === "number") {
-          score = value;
+          score = value >= 0.5 ? 1 : 0;
         }
 
         chartData.push({

--- a/src/components/FairAssessment.vue
+++ b/src/components/FairAssessment.vue
@@ -2,7 +2,7 @@
   <eox-chart
     :spec.prop="chartSpec"
     :dataValues.prop="chartData"
-  >Hi there!</eox-chart>
+  ></eox-chart>
 </template>
 
 <script>

--- a/src/components/FairAssessment.vue
+++ b/src/components/FairAssessment.vue
@@ -18,58 +18,97 @@ export default {
     },
   },
   mounted() {
-    // --- Data Processing ---
+    const fair_descriptions = {
+      "fair:product_url_resolves": "Test whether the dataset URL resolves successfully.",
+      "fair:product_has_doi": "Test whether the dataset has an associated DOI.",
+      "fair:product_has_documentation": "Test whether the dataset has documentation.",
+      "fair:product_approved_metadata_domain": "Test whether the metadata is hosted on an approved domain.",
+      "fair:product_approved_data_domain": "Test whether the data is hosted on an approved domain.",
+      "fair:file_access": "Test whether the metadata has per-file metadata, or if the data is a raw dump.",
+      "fair:file_acessible_files_rate": "Percent of assets that could be opened in tests.",
+      "fair:file_cloud_assets_rate": "Percent of assets that are in cloud-optimised format.",
+      "fair:workflow_exists": "Dataset has associated workflow."
+    };
 
     /**
      * Helper function to convert keys like "acessible_files_rate" or "product"
      * into "Acessible files rate" or "Product"
      */
-      function prettify(str) {
+    function prettify(str) {
       if (!str) return "";
       return str
         .replace(/[_-]/g, " ") // Replace underscores/hyphens with spaces
         .replace(/\b\w/g, (char) => char.toUpperCase()); // Capitalize first letter of each word
     }
 
-    // Transform the nested JSON into a flat array for Vega-Lite
-    const accessData = this.collection.access;
-    if (!accessData) {
-      // No access data available
-      return;
-    }
     const chartData = [];
     let totalMetrics = 0;
     let trueMetrics = 0;
 
-    for (const groupName in accessData) {
-      const groupData = accessData[groupName];
-      
-      // Create the clean, capitalized label for the group, e.g., "Product"
-      const groupLabel = prettify(groupName.split(":").pop());
+    if (this.collection.access && typeof this.collection.access === 'object' && !Array.isArray(this.collection.access)) {
+      // Old structure
+      for (const groupName in this.collection.access) {
+        const groupData = this.collection.access[groupName];
+        const groupLabel = prettify(groupName.split(":").pop());
 
-      for (const metricName in groupData) {
-        const metricData = groupData[metricName];
-        const value = metricData.value;
-        const score = value ? 1 : 0; // 1 for true (pass), 0 for false (fail)
-        
-        // Create the clean label for the metric
-        const metricLabel = prettify(metricName);
+        for (const metricName in groupData) {
+          const metricData = groupData[metricName];
+          const value = metricData.value;
+          const score = value ? 1 : 0;
+          const metricLabel = prettify(metricName);
+
+          chartData.push({
+            group: groupName,
+            groupLabel: groupLabel,
+            metric: metricName,
+            metricLabel: metricLabel,
+            value: value,
+            score: score,
+            description: metricData.description,
+          });
+
+          totalMetrics++;
+          trueMetrics += score;
+        }
+      }
+    } else {
+      // New structure
+      for (const key in fair_descriptions) {
+        if (typeof this.collection[key] === "undefined") {
+          continue;
+        }
+
+        const value = this.collection[key];
+        const metricName = key.replace("fair:", "");
+        const groupName = metricName.split("_")[0];
+
+        const groupLabel = prettify(groupName);
+        const metricLabel = prettify(metricName.replace(groupName + "_", ""));
+
+        let score = 0;
+        if (typeof value === "boolean") {
+          score = value ? 1 : 0;
+        } else if (typeof value === "number") {
+          score = value;
+        }
 
         chartData.push({
           group: groupName,
           groupLabel: groupLabel,
-          metric: metricName,
+          metric: key,
           metricLabel: metricLabel,
           value: value,
           score: score,
-          description: metricData.description,
+          description: fair_descriptions[key],
         });
 
         totalMetrics++;
-        if (value) {
-          trueMetrics++;
-        }
+        trueMetrics += score;
       }
+    }
+
+    if (chartData.length === 0) {
+      return;
     }
 
     // Calculate overall percentage for the center label
@@ -153,7 +192,6 @@ export default {
               title: "Access Category",
             },
             
-            // *** THIS IS THE NEWLY ADDED SECTION ***
             // Opacity is the average score of the group (0.0 to 1.0)
             opacity: {
               "field": "score",
@@ -163,7 +201,6 @@ export default {
               "scale": {"range": [0.3, 1.0]}, 
               "legend": null
             },
-            // *** END OF NEW SECTION ***
 
             // Order segments by group
             order: { field: "group" },

--- a/src/components/FairAssessment.vue
+++ b/src/components/FairAssessment.vue
@@ -1,0 +1,237 @@
+<template>
+  <eox-chart
+    :spec.prop="chartSpec"
+    :dataValues.prop="chartData"
+  >Hi there!</eox-chart>
+</template>
+
+<script>
+export default {
+  data: () => ({
+    chartSpec: null,
+    chartData: null,
+  }),
+  props: {
+    collection: {
+      type: Object,
+      default: {},
+    },
+  },
+  mounted() {
+    // --- Data Processing ---
+
+    /**
+     * Helper function to convert keys like "acessible_files_rate" or "product"
+     * into "Acessible files rate" or "Product"
+     */
+      function prettify(str) {
+      if (!str) return "";
+      return str
+        .replace(/[_-]/g, " ") // Replace underscores/hyphens with spaces
+        .replace(/\b\w/g, (char) => char.toUpperCase()); // Capitalize first letter of each word
+    }
+
+    // Transform the nested JSON into a flat array for Vega-Lite
+    const accessData = this.collection.access;
+    if (!accessData) {
+      // No access data available
+      return;
+    }
+    const chartData = [];
+    let totalMetrics = 0;
+    let trueMetrics = 0;
+
+    for (const groupName in accessData) {
+      const groupData = accessData[groupName];
+      
+      // Create the clean, capitalized label for the group, e.g., "Product"
+      const groupLabel = prettify(groupName.split(":").pop());
+
+      for (const metricName in groupData) {
+        const metricData = groupData[metricName];
+        const value = metricData.value;
+        const score = value ? 1 : 0; // 1 for true (pass), 0 for false (fail)
+        
+        // Create the clean label for the metric
+        const metricLabel = prettify(metricName);
+
+        chartData.push({
+          group: groupName,
+          groupLabel: groupLabel,
+          metric: metricName,
+          metricLabel: metricLabel,
+          value: value,
+          score: score,
+          description: metricData.description,
+        });
+
+        totalMetrics++;
+        if (value) {
+          trueMetrics++;
+        }
+      }
+    }
+
+    // Calculate overall percentage for the center label
+    const overallPercentage =
+      totalMetrics > 0
+        ? Math.round((trueMetrics / totalMetrics) * 100)
+        : 0;
+
+    // Create a separate data source for the center text
+    const scoreData = [
+      {
+        percent: overallPercentage,
+        label: `${overallPercentage}%`,
+      },
+    ];
+    // --- End Data Processing ---
+
+    // --- Vega-Lite Specification ---
+    const chartSpec = {
+      $schema: "https://vega.github.io/schema/vega-lite/v5.json",
+      description: "FAIR Accessibility Donut Chart",
+      layer: [
+        {
+          // Layer 1: Inner Ring (The Metrics)
+          data: { name: "myData" },
+          mark: {
+            type: "arc",
+            outerRadius: 80,
+            innerRadius: 50,
+            stroke: "#fff",
+          },
+          encoding: {
+            // Each metric gets an equal slice
+            theta: { aggregate: "count", stack: true },
+            // Color matches the group
+            color: { field: "group", type: "nominal", legend: null },
+            // Opacity shows the individual score (pass/fail)
+            opacity: {
+              field: "score", // 0 or 1
+              type: "quantitative",
+              scale: { range: [0.4, 1.0] }, // 0=40%, 1=100%
+              legend: null,
+            },
+            // Order segments by group to keep them together
+            order: { field: "group" },
+            // Add inner labels
+            text: {
+              field: "metricLabel",
+              type: "nominal",
+              fontSize: 9,
+              color: "#333",
+            },
+            tooltip: [
+              { field: "metricLabel", title: "Metric" },
+              { field: "group", title: "Category" },
+              { field: "value", title: "Passed" },
+              { field: "description", title: "Description" },
+            ],
+          },
+        },
+        {
+          // Layer 2: Outer Ring (The Groups)
+          data: { name: "myData" },
+          mark: {
+            type: "arc",
+            outerRadius: 110,
+            innerRadius: 80,
+            stroke: "#fff",
+          },
+          encoding: {
+            // The angle (theta) is proportional to the count of metrics in the group
+            theta: {
+              field: "metric",
+              aggregate: "count",
+              stack: true,
+            },
+            // Color is based on the group name
+            color: {
+              field: "group",
+              type: "nominal",
+              title: "Access Category",
+            },
+            
+            // *** THIS IS THE NEWLY ADDED SECTION ***
+            // Opacity is the average score of the group (0.0 to 1.0)
+            opacity: {
+              "field": "score",
+              "aggregate": "mean", // Calculates the average (pass rate)
+              "type": "quantitative",
+              // Map [0, 1] to [30%, 100%] so 0% is still visible
+              "scale": {"range": [0.3, 1.0]}, 
+              "legend": null
+            },
+            // *** END OF NEW SECTION ***
+
+            // Order segments by group
+            order: { field: "group" },
+            tooltip: [
+              { field: "group", title: "Category" },
+              { aggregate: "count", title: "Metrics" },
+              // Added pass rate to the group tooltip
+              { 
+                "aggregate": "mean", 
+                "field": "score", 
+                "title": "Pass Rate", 
+                "format": ".0%" // Format as percentage
+              }
+            ],
+          },
+        },
+        {
+          // Layer 3: Outer Text Labels (for Groups)
+          data: { name: "myData" },
+          mark: {
+            type: "text",
+            radius: 125, 
+            fill: "#444",
+            fontSize: 10,
+          },
+          encoding: {
+            theta: {
+              field: "metric",
+              aggregate: "count",
+              stack: true,
+            },
+            text: { field: "groupLabel", type: "nominal" },
+            order: { field: "group" },
+          },
+        },
+        {
+          // Layer 4: Center Text (The Score)
+          data: { name: "scoreData" },
+          mark: {
+            type: "text",
+            fontSize: 30,
+            fontWeight: "bold",
+            color: "#111",
+          },
+          encoding: {
+            text: { field: "label", type: "nominal" },
+          },
+        },
+      ],
+      view: {
+        // Remove the default square border around the chart
+        stroke: null,
+      },
+    };
+    // --- End Spec ---
+
+    this.chartSpec = chartSpec;
+    this.chartData = {
+      myData: chartData,
+      scoreData: scoreData,
+    };
+  }
+};
+</script>
+
+<style scoped>
+eox-chart {
+  width: 400px;
+  height: 400px;
+}
+</style>

--- a/src/locales/en/custom.json
+++ b/src/locales/en/custom.json
@@ -9,5 +9,6 @@
     "Time of Data ends": "End date"
   },
   "browse": "Overview",
-  "topics": "Related EarthCODE Forum Topics"
+  "topics": "Related EarthCODE Forum Topics",
+  "fairAssessment": "FAIR Assessment"
 }

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -34,6 +34,10 @@
             </b-tabs>
           </b-card>
         </section>
+        <section v-if="isCollection && data.access" class="mb-4">
+          <h2>{{ $t('fairAssessment') }}</h2>
+          <FairAssessment :collection="data" />
+        </section>
         <section v-if="isCollection" class="mb-4">
           <h2>{{ $t('topics') }}</h2>
           <ForumTopics
@@ -70,6 +74,7 @@
 import { mapState, mapGetters } from 'vuex';
 import Catalogs from '../components/Catalogs.vue';
 import Description from '../components/Description.vue';
+import FairAssessment from "../components/FairAssessment";
 import ForumTopics from "../components/ForumTopics";
 import Items from '../components/Items.vue';
 import ReadMore from "vue-read-more-smooth";
@@ -92,6 +97,7 @@ export default {
     CollectionLink: () => import('../components/CollectionLink.vue'),
     DeprecationNotice: () => import('../components/DeprecationNotice.vue'),
     Description,
+    FairAssessment,
     ForumTopics,
     Items,
     Keywords: () => import('../components/Keywords.vue'),

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -34,7 +34,7 @@
             </b-tabs>
           </b-card>
         </section>
-        <section v-if="isCollection && data.access" class="mb-4">
+        <section v-if="isCollection && hasFairAssessment" class="mb-4">
           <h2>{{ $t('fairAssessment') }}</h2>
           <FairAssessment :collection="data" />
         </section>
@@ -115,40 +115,6 @@ export default {
   data() {
     return {
       filters: {},
-      ignoredMetadataFields: [
-        // Catalog and Collection fields that are handled directly
-        'stac_version',
-        'stac_extensions',
-        'id',
-        'type',
-        'title',
-        'description',
-        'keywords',
-        'providers',
-        'license',
-        'extent',
-        'summaries',
-        'links',
-        'assets',
-        'item_assets',
-        // Don't show these complex lists of coordinates: https://github.com/radiantearth/stac-browser/issues/141
-        'proj:bbox',
-        'proj:geometry',
-        // API landing page, not very useful to display, but https://github.com/radiantearth/stac-browser/issues/136
-        'conformsTo',
-        // Will be rendered with a custom rendered
-        'deprecated',
-        // Special handling for the warning of the anonymized-location extension
-        'anon:warning',
-        // Special handling for the stats extension
-        'stats:catalogs',
-        'stats:collections',
-        'stats:items',
-        // Special handling for auth
-        'auth:schemes',
-        // Special handling for the STAC Browser config
-        'stac_browser'
-      ],
       forumTopicData: null,
     };
   },
@@ -227,6 +193,57 @@ export default {
     },
     hasCatalogs() {
       return this.catalogs.length > 0;
+    },
+    hasFairAssessment() {
+      return (
+        Utils.isObject(this.data.access) ||
+        Object.keys(this.data).some((key) => key.startsWith("fair:"))
+      );
+    },
+    ignoredMetadataFields() {
+      const fields = [
+        // Catalog and Collection fields that are handled directly
+        "stac_version",
+        "stac_extensions",
+        "id",
+        "type",
+        "title",
+        "description",
+        "keywords",
+        "providers",
+        "license",
+        "extent",
+        "summaries",
+        "links",
+        "assets",
+        "item_assets",
+        // Don't show these complex lists of coordinates: https://github.com/radiantearth/stac-browser/issues/141
+        "proj:bbox",
+        "proj:geometry",
+        // API landing page, not very useful to display, but https://github.com/radiantearth/stac-browser/issues/136
+        "conformsTo",
+        // Will be rendered with a custom rendered
+        "deprecated",
+        // Special handling for the warning of the anonymized-location extension
+        "anon:warning",
+        // Special handling for the stats extension
+        "stats:catalogs",
+        "stats:collections",
+        "stats:items",
+        // Special handling for auth
+        "auth:schemes",
+        // Special handling for the STAC Browser config
+        "stac_browser",
+        // Special handling for FAIR Assessment
+        "access",
+      ];
+      // Ignore all fair: fields
+      Object.keys(this.data).forEach((key) => {
+        if (key.startsWith("fair:")) {
+          fields.push(key);
+        }
+      });
+      return fields;
     },
     mapData() {
       if (this.selectedAsset) {


### PR DESCRIPTION
This pull request introduces a new FAIR Assessment donut chart visualization for collections, enhancing the user experience by showing accessibility metrics in a clear, interactive format. The main changes include integrating the `eox-chart` library, adding a new `FairAssessment` Vue component, and updating the catalog view to display the chart when appropriate.

<img width="783" height="455" alt="image" src="https://github.com/user-attachments/assets/cf0666ba-7cd9-4be9-8b57-3fdd7a7f507e" />


**FAIR Assessment Chart Integration**

* Added the `FairAssessment.vue` component, which processes accessibility metrics from a collection and renders them as a multi-layered donut chart using the `eox-chart` library. The chart visually represents individual metric results, group pass rates, and an overall score.
* Included the `@eox/chart` module via CDN in `public/index.html` to enable chart rendering.

**Catalog View Updates**

* Updated `Catalog.vue` to conditionally show the FAIR Assessment chart for collections with accessibility data, including the new section and component import. [[1]](diffhunk://#diff-e5ae29665fdce75bf0ae8a5f29a748c0d4bd198bef31bae2401c7d333390d596R37-R40) [[2]](diffhunk://#diff-e5ae29665fdce75bf0ae8a5f29a748c0d4bd198bef31bae2401c7d333390d596R77) [[3]](diffhunk://#diff-e5ae29665fdce75bf0ae8a5f29a748c0d4bd198bef31bae2401c7d333390d596R100)

**Localization**

* Added a new localization string for "FAIR Assessment" in the English custom locale file.

Implements #14.